### PR TITLE
Plugin/drip option template

### DIFF
--- a/src/plugins/drip_custom_width/plugin.js
+++ b/src/plugins/drip_custom_width/plugin.js
@@ -1,0 +1,21 @@
+/**
+ * Plugin: "drip_custom_width" (selectize.js)
+ *
+ * Allows explicit width of a select to be passed
+ * in during initialization
+ *
+ * ex. $(el).selectize({ width: 275 });
+ */
+
+Selectize.define('drip_custom_width', function(options) {
+  var self = this;
+  var original = self.setup;
+
+  this.setup = (function() {
+    if (self.settings.width) {
+      self.$input[0].style.width = self.settings.width + 'px';
+    }
+
+    original.apply(self, arguments);
+  });
+});

--- a/src/plugins/drip_option_template/plugin.js
+++ b/src/plugins/drip_option_template/plugin.js
@@ -12,7 +12,6 @@
  *
  */
 
-
 Selectize.define('drip_option_template', function(options) {
   var self = this;
   var original = self.setupTemplates;

--- a/src/plugins/drop_option_template/plugin.js
+++ b/src/plugins/drop_option_template/plugin.js
@@ -1,0 +1,46 @@
+/**
+ * Plugin: "drip_option_template" (selectize.js)
+ *
+ * Handles Drip's previous <select> markup where
+ * <option>s that had a secondary line in their
+ * UI would be rendered with `data-description`
+ * attributes.
+ *
+ * This plugin checks for `data-description` on
+ * <option>s and replaces the default 'option'
+ * template with one that shows the description text
+ *
+ */
+
+
+Selectize.define('drip_option_template', function(options) {
+  var self = this;
+  var original = self.setupTemplates;
+
+  // if source <select>'s <option>s have `data-description`
+  // attrs, extract and append to Selectize's `options`
+  var selectOptions = self.$input[0].options;
+
+  for (var i = 0; i < selectOptions.length; i++) {
+    if (selectOptions[i].dataset.hasOwnProperty('description')) {
+      this.options[selectOptions[i].value]['description'] = selectOptions[i].dataset.description;
+    }
+  }
+
+  // add custom template to available option templates
+  this.setupTemplates = (function() {
+    var templates = {
+      'option': function(data, escape) {
+        return ('<div class="option">' +
+          escape(data[self.settings.labelField]) +
+          (data.description ? '<div class="desc">' + data.description + '</div>' : '') +
+          '</div>');
+      }
+    };
+
+    self.settings.render = $.extend({}, templates, self.settings.render);
+    original.apply(self, arguments);
+  });
+
+});
+


### PR DESCRIPTION
This PR adds two plugins:
1. `drip_option_template` overwrites the default `option` template with one that can handle supplemental data. 

1. `drip_custom_width` allows a specific `width` to be set when Selectize is initialized. 
ex: `$(el).selectize({ width: 275 });` sets the generated select's width to 275px.