### PR TITLE
Remove highlighted characters on close

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1764,6 +1764,7 @@ $.extend(Selectize.prototype, {
 
 		self.isOpen = false;
 		self.$dropdown.hide();
+		self.$dropdown_content.removeHighlight();
 		self.setActiveOption(null);
 		self.refreshState();
 


### PR DESCRIPTION
Fixed bug where single-letter highlights persisted after dropdown was closed.