### PR TITLE
Plugin/combo select

### DIFF
--- a/src/plugins/drip_option_template/plugin.js
+++ b/src/plugins/drip_option_template/plugin.js
@@ -24,6 +24,13 @@ Selectize.define('drip_option_template', function(options) {
     if (selectOptions[i].dataset.hasOwnProperty('description')) {
       this.options[selectOptions[i].value]['description'] = selectOptions[i].dataset.description;
     }
+    // for combo-selects
+    // if original <option> has `data-combotrigger` attribute,
+    // this adds it to the option data, which will pass it
+    // to the rendered option
+		if (selectOptions[i].dataset.hasOwnProperty('combotrigger'))
+      this.options[selectOptions[i].value]['combotrigger'] = selectOptions[i].dataset.combotrigger;
+    }
   }
 
   // add custom template to available option templates

--- a/src/plugins/drip_option_template/plugin.js
+++ b/src/plugins/drip_option_template/plugin.js
@@ -28,7 +28,7 @@ Selectize.define('drip_option_template', function(options) {
     // if original <option> has `data-combotrigger` attribute,
     // this adds it to the option data, which will pass it
     // to the rendered option
-		if (selectOptions[i].dataset.hasOwnProperty('combotrigger'))
+		if (selectOptions[i].dataset.hasOwnProperty('combotrigger')) {
       this.options[selectOptions[i].value]['combotrigger'] = selectOptions[i].dataset.combotrigger;
     }
   }

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1701,7 +1701,7 @@ $.extend(Selectize.prototype, {
 			options = [];
 			for (i = 0, n = self.items.length; i < n; i++) {
 				label = self.options[self.items[i]][self.settings.labelField] || '';
-				options.push('<option value="' + escape_html(self.items[i]) + '" selected="selected">' + escape_html(label) + '</option>');
+        options.push('<option value="' + escape_html(self.items[i]) + '" data-combotrigger="' + (self.options[self.items[i]].combotrigger ? true : false) + '" selected="selected">' + escape_html(label) + '</option>');
 			}
 			if (!options.length && !this.$input.attr('multiple')) {
 				options.push('<option value="" selected="selected"></option>');


### PR DESCRIPTION
This PR adds more custom logic to Selectize. 

Selectize doesn't keep an `<option>`'s original `data` attributes.
When an <option> has `data-combotrigger`, this PR ensure that this value makes its way to the Selectize-rendered `<option>`