### PR TITLE
If in a modal, restore focus to modal on close

### DIFF
--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1763,6 +1763,11 @@ $.extend(Selectize.prototype, {
 			self.hideInput();
 			setTimeout(function() {
 				self.$control_input.blur(); // close keyboard on iOS
+        // if dropdown lives in a modal, restore focus to modal
+        // so ESC key still closes modal
+        if (self.$control_input.parents('.modal').length) {
+          self.$control_input.parents('.modal').focus()
+        }
 			});
 		}
 

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1763,11 +1763,12 @@ $.extend(Selectize.prototype, {
 			self.hideInput();
 			setTimeout(function() {
 				self.$control_input.blur(); // close keyboard on iOS
-        // if dropdown lives in a modal, restore focus to modal
-        // so ESC key still closes modal
-        if (self.$control_input.parents('.modal').length) {
-          self.$control_input.parents('.modal').focus()
-        }
+				
+				// if dropdown lives in a modal, restore focus to modal
+				// so ESC key still closes modal
+				if (self.$control_input.parents('.modal').length) {
+					self.$control_input.parents('.modal').focus()
+				}
 			});
 		}
 


### PR DESCRIPTION
Fix for select's that appear in modals. Now on close, if a select is in a modal, focus is restored to the modal so the Escape key still closes the modal.