### PR TITLE
Handle option data attributes

### DIFF
--- a/src/plugins/drip_option_template/plugin.js
+++ b/src/plugins/drip_option_template/plugin.js
@@ -22,9 +22,10 @@ Selectize.define('drip_option_template', function(options) {
   // pass them through to Selectize
   for (var i = 0; i < selectOptions.length; i++) {
     if (Object.keys(selectOptions[i].dataset).length > 0) {
+      this.options[selectOptions[i].value]['data'] = {};
       data_attrs = Object.keys(selectOptions[i].dataset);
       for (var j = 0; j < data_attrs.length; j++) {
-        this.options[selectOptions[i].value][data_attrs[j]] = selectOptions[i].dataset[data_attrs[j]];
+        this.options[selectOptions[i].value].data[data_attrs[j]] = selectOptions[i].dataset[data_attrs[j]];
       }
     }
   }

--- a/src/plugins/drip_option_template/plugin.js
+++ b/src/plugins/drip_option_template/plugin.js
@@ -21,7 +21,7 @@ Selectize.define('drip_option_template', function(options) {
   // If any `data-attrs` are present on the source `option` els,
   // pass them through to Selectize
   for (var i = 0; i < selectOptions.length; i++) {
-		if (Object.keys(selectOptions[i].dataset).length > 0) {
+    if (Object.keys(selectOptions[i].dataset).length > 0) {
       data_attrs = Object.keys(selectOptions[i].dataset);
       for (var j = 0; j < data_attrs.length; j++) {
         this.options[selectOptions[i].value][data_attrs[j]] = selectOptions[i].dataset[data_attrs[j]];

--- a/src/plugins/drip_option_template/plugin.js
+++ b/src/plugins/drip_option_template/plugin.js
@@ -15,31 +15,17 @@
 Selectize.define('drip_option_template', function(options) {
   var self = this;
   var original = self.setupTemplates;
-
-  // if source <select>'s <option>s have `data-description`
-  // attrs, extract and append to Selectize's `options`
   var selectOptions = self.$input[0].options;
+  var data_attrs;
 
+  // If any `data-attrs` are present on the source `option` els,
+  // pass them through to Selectize
   for (var i = 0; i < selectOptions.length; i++) {
-    if (selectOptions[i].dataset.hasOwnProperty('description')) {
-      this.options[selectOptions[i].value]['description'] = selectOptions[i].dataset.description;
-    }
-    // for combo-selects
-    // if original <option> has `data-combotrigger` attribute,
-    // this adds it to the option data, which will pass it
-    // to the rendered option
-		if (selectOptions[i].dataset.hasOwnProperty('combotrigger')) {
-      this.options[selectOptions[i].value]['combotrigger'] = selectOptions[i].dataset.combotrigger;
-    }
-
-    // passes along data-type atrributes
-    if (selectOptions[i].dataset.hasOwnProperty('type')) {
-      this.options[selectOptions[i].value]['type'] = selectOptions[i].dataset.type;
-    }
-
-    // passes along data-type atrributes
-    if (selectOptions[i].dataset.hasOwnProperty('path')) {
-      this.options[selectOptions[i].value]['path'] = selectOptions[i].dataset.path;
+		if (Object.keys(selectOptions[i].dataset).length > 0) {
+      data_attrs = Object.keys(selectOptions[i].dataset);
+      for (var j = 0; j < data_attrs.length; j++) {
+        this.options[selectOptions[i].value][data_attrs[j]] = selectOptions[i].dataset[data_attrs[j]];
+      }
     }
   }
 

--- a/src/selectize.js
+++ b/src/selectize.js
@@ -1694,19 +1694,23 @@ $.extend(Selectize.prototype, {
 	 * element to reflect the current state.
 	 */
 	updateOriginalInput: function(opts) {
-		var i, n, options, label, self = this;
+		var i, n, options, label, data_markup, self = this;
 		opts = opts || {};
 
 		if (self.tagType === TAG_SELECT) {
 			options = [];
 			for (i = 0, n = self.items.length; i < n; i++) {
-				label = self.options[self.items[i]][self.settings.labelField] || '';
-        options.push('<option value="' +
-          escape_html(self.items[i]) +
-          '" data-combotrigger="' + (self.options[self.items[i]].combotrigger ? true : false) + '"' +
-          (self.options[self.items[i]].type ? ' data-type="' + self.options[self.items[i]].type : '') + '"' +
-          (self.options[self.items[i]].path ? ' data-path="' + self.options[self.items[i]].path : '') + '"' +
-          ' selected="selected">' + escape_html(label) + '</option>');
+        label = self.options[self.items[i]][self.settings.labelField] || '';
+        data_markup = '';
+
+        if (self.options[self.items[i]].hasOwnProperty('data')) {
+          var data_obj = self.options[self.items[i]].data;
+          for (var j = 0; j < Object.keys(data_obj).length; j++) {
+            data_markup += ' data-' + Object.keys(data_obj)[j] + '="' + data_obj[Object.keys(data_obj)[j]] + '"';
+          }
+        }
+
+        options.push('<option value="' + escape_html(self.items[i]) + '"' + data_markup + ' selected="selected">' + escape_html(label) + '</option>');
 			}
 			if (!options.length && !this.$input.attr('multiple')) {
 				options.push('<option value="" selected="selected"></option>');


### PR DESCRIPTION
This PR cleans up logic around storing and rendering option `data-attrs`. 
Instead of adding every single case, check for any `data-attrs` and render them automatically.