### PR TITLE
Grunt watch update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 bower_components
 *.log
+.env

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 var fs = require('fs');
 
 module.exports = function(grunt) {
@@ -240,7 +242,7 @@ module.exports = function(grunt) {
 				command: 'grunt --plugins=drip_custom_width,drip_delete_on_mousedown,drip_option_template'
 			},
 			copy_lib: {
-				command: 'cp dist/js/standalone/selectize.js ~/drip/drip/vendor/assets/javascripts/selectize.js'
+				command: 'cp dist/js/standalone/selectize.js ' + process.env.DEST
 			}
 		}
 	});

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,7 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-less');
 	grunt.loadNpmTasks('grunt-contrib-watch');
 	grunt.loadNpmTasks('grunt-replace');
+	grunt.loadNpmTasks('grunt-shell');
 
 	grunt.registerTask('configure', [
 		'clean:pre',
@@ -230,9 +231,17 @@ module.exports = function(grunt) {
 				'src/**/*.js'
 			],
 			tasks: [
-				'concat:js',
-				'build_standalone'
+				'shell:build_with_plugins',
+				'shell:copy_lib'
 			]
+		},
+		shell: {
+			build_with_plugins: {
+				command: 'grunt --plugins=drip_custom_width,drip_delete_on_mousedown,drip_option_template'
+			},
+			copy_lib: {
+				command: 'cp dist/js/standalone/selectize.js ~/drip/drip/vendor/assets/javascripts/selectize.js'
+			}
 		}
 	});
 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "grunt-contrib-uglify": "^2.0.0",
     "grunt-contrib-watch": "1.x",
     "grunt-replace": "^1.0.1",
+    "grunt-shell": "^2.1.0",
     "karma": "^1.3.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "dotenv": "^4.0.0",
     "grunt": "~1.0.1",
     "grunt-bower-task": "^0.4.0",
     "grunt-cli": "^1.2.0",


### PR DESCRIPTION
Streamline development process with by copying the Drip-specific build into the Drip application automatically with `grunt watch`